### PR TITLE
Add support for Wasm atomics

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
+
+const Builder = if (builtin.zig_version.minor <= 10) std.build.Builder else std.Build;
+const Mode = if (builtin.zig_version.minor <= 10) std.builtin.Mode else std.builtin.OptimizeMode;
 
 const Target = std.Target;
 const CrossTarget = std.zig.CrossTarget;
@@ -6,15 +10,25 @@ const CrossTarget = std.zig.CrossTarget;
 const Arch = Target.Cpu.Arch;
 const Os = Target.Os.Tag;
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *Builder) void {
+    if (comptime builtin.zig_version.minor <= 10) {
+        build_v10(b);
+    } else {
+        build_v11(b);
+    }
+}
+
+fn build_v10(b: *std.build.Builder) void {
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const mode = b.standardReleaseOptions();
     const coverage = b.option(bool, "coverage", "Generate test coverage") orelse false;
 
     // Docs
-    const linux_64 = build_target(b, mode, Arch.x86_64, Os.linux);
-    linux_64.install();
+    const docs = b.addStaticLibrary("zig-rc", "src/main.zig");
+    docs.emit_docs = .emit;
+    docs.setBuildMode(mode);
+    docs.install();
 
     // Tests
     const main_tests = b.addTest("src/tests.zig");
@@ -39,12 +53,55 @@ pub fn build(b: *std.build.Builder) void {
     example_step.dependOn(&example.step);
 }
 
-fn build_target(b: *std.build.Builder, mode: std.builtin.Mode, arch: Target.Cpu.Arch, os_tag: Target.Os.Tag) *std.build.LibExeObjStep {
-    const lib = b.addStaticLibrary("zig-rc", "src/main.zig");
-    lib.emit_docs = .emit;
-    lib.setBuildMode(mode);
-    lib.setTarget(CrossTarget.fromTarget(default_target(arch, os_tag)));
-    return lib;
+fn build_v11(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
+
+    const coverage = b.option(bool, "coverage", "Generate test coverage") orelse false;
+
+    // Docs
+    const docs = b.addStaticLibrary(.{
+        .name = "zig-rc",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    docs.emit_docs = .emit;
+    b.installArtifact(docs);
+
+    // Tests
+    const main_tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/tests.zig" },
+    });
+    const run_main_tests = b.addRunArtifact(main_tests);
+
+    if (coverage) {
+        main_tests.setExecCmd(&[_]?[]const u8{
+            "kcov",
+            "--include-pattern=src/main.zig,src/tests.zig",
+            "kcov-out",
+            null, // to get zig to use the --test-cmd-bin flag
+        });
+    }
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&run_main_tests.step);
+
+    // Examples
+    const example = b.addTest(.{
+        .root_source_file = .{ .path = "src/example.zig" },
+    });
+    const run_example = b.addRunArtifact(example);
+    const example_step = b.step("example", "Run library example");
+    example_step.dependOn(&run_example.step);
 }
 
 fn default_target(arch: Target.Cpu.Arch, os_tag: Target.Os.Tag) Target {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,11 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+/// This variable is `true` if an atomic reference-counter is used for `Arc`, `false` otherwise.
+///
+/// If the target is single-threaded, `Arc` is optimized to a regular `Rc`.
+pub const atomic_arc = !builtin.single_threaded or (builtin.target.isWasm() and std.Target.wasm.featureSetHas(builtin.cpu.features, .atomics));
+
 /// A single threaded, strong reference to a reference-counted value.
 pub fn Rc(comptime T: type) type {
     return struct {
@@ -128,15 +133,13 @@ pub fn Rc(comptime T: type) type {
         }
 
         /// Total size (in bytes) of the reference counted value on the heap.
-        /// This value accounts for the extra memory required to count the references,
-        /// and is valid for single and multi-threaded refrence counters.
+        /// This value accounts for the extra memory required to count the references.
         pub fn innerSize() comptime_int {
             return Inner.innerSize();
         }
 
         /// Alignment (in bytes) of the reference counted value on the heap.
-        /// This value accounts for the extra memory required to count the references,
-        /// and is valid for single and multi-threaded refrence counters.
+        /// This value accounts for the extra memory required to count the references.
         pub fn innerAlign() comptime_int {
             return Inner.innerAlign();
         }
@@ -147,7 +150,7 @@ pub fn Rc(comptime T: type) type {
 
         /// A single threaded, weak reference to a reference-counted value.
         pub const Weak = struct {
-            inner: ?*align(@alignOf(Inner)) anyopaque = null,
+            inner: ?*Inner = null,
             alloc: std.mem.Allocator,
 
             /// Creates a new weak reference.
@@ -236,7 +239,7 @@ pub fn Rc(comptime T: type) type {
 
 /// A multi-threaded, strong reference to a reference-counted value.
 pub fn Arc(comptime T: type) type {
-    if (builtin.single_threaded) {
+    if (!atomic_arc) {
         return Rc(T);
     }
 
@@ -355,15 +358,13 @@ pub fn Arc(comptime T: type) type {
         }
 
         /// Total size (in bytes) of the reference counted value on the heap.
-        /// This value accounts for the extra memory required to count the references,
-        /// and is valid for single and multi-threaded refrence counters.
+        /// This value accounts for the extra memory required to count the references.
         pub fn innerSize() comptime_int {
             return Inner.innerSize();
         }
 
         /// Alignment (in bytes) of the reference counted value on the heap.
-        /// This value accounts for the extra memory required to count the references,
-        /// and is valid for single and multi-threaded refrence counters.
+        /// This value accounts for the extra memory required to count the references.
         pub fn innerAlign() comptime_int {
             return Inner.innerAlign();
         }
@@ -374,7 +375,7 @@ pub fn Arc(comptime T: type) type {
 
         /// A multi-threaded, weak reference to a reference-counted value.
         pub const Weak = struct {
-            inner: ?*align(@alignOf(Inner)) anyopaque = null,
+            inner: ?*Inner = null,
             alloc: std.mem.Allocator,
 
             /// Creates a new weak reference.
@@ -449,15 +450,13 @@ pub fn Arc(comptime T: type) type {
             }
 
             /// Total size (in bytes) of the reference counted value on the heap.
-            /// This value accounts for the extra memory required to count the references,
-            /// and is valid for single and multi-threaded refrence counters.
+            /// This value accounts for the extra memory required to count the references.
             pub fn innerSize() comptime_int {
                 return Inner.innerSize();
             }
 
             /// Alignment (in bytes) of the reference counted value on the heap.
-            /// This value accounts for the extra memory required to count the references,
-            /// and is valid for single and multi-threaded refrence counters.
+            /// This value accounts for the extra memory required to count the references.
             pub fn innerAlign() comptime_int {
                 return Inner.innerAlign();
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -467,3 +467,13 @@ pub fn Arc(comptime T: type) type {
         };
     };
 }
+
+/// Creates a new `Rc` inferring the type of `value`
+pub fn rc(alloc: std.mem.Allocator, value: anytype) std.mem.Allocator.Error!Rc(@TypeOf(value)) {
+    return Rc(@TypeOf(value)).init(alloc, value);
+}
+
+/// Creates a new `Arc` inferring the type of `value`
+pub fn arc(alloc: std.mem.Allocator, value: anytype) std.mem.Allocator.Error!Arc(@TypeOf(value)) {
+    return Arc(@TypeOf(value)).init(alloc, value);
+}


### PR DESCRIPTION
This PR adds:
- Support for WebAssembly atomics
- Support for building to v0.11.0
- Creation of inferred types