### PR TITLE
Add closure-like function arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Aandreba/zigrc/tests.yml)
-[![Docs](https://img.shields.io/badge/docs-zig-blue)](https://aandreba.github.io/zigrc/#zig-rc.main)
+[![Docs](https://img.shields.io/badge/docs-zig-blue)](https://aandreba.github.io/zigrc)
 
 # zigrc
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -65,7 +65,7 @@ test "cyclic" {
         const Weak = Rc.Weak;
 
         pub fn init(allocator: std.mem.Allocator) !Rc {
-            return Rc.initCyclic(allocator, Self.data_fn);
+            return Rc.initCyclic(allocator, Self.data_fn, .{});
         }
 
         pub fn me(self: *Self) Rc {
@@ -82,7 +82,7 @@ test "cyclic" {
     };
 
     var gadget = try Gadget.init(alloc);
-    defer gadget.releaseWithFn(Gadget.deinit);
+    defer gadget.releaseWithFn(Gadget.deinit, .{});
 
     try expect(gadget.strongCount() == 1);
     try expect(gadget.weakCount() == 1);
@@ -149,7 +149,7 @@ test "cyclic atomic" {
         const Weak = Rc.Weak;
 
         pub fn init(allocator: std.mem.Allocator) !Rc {
-            return Rc.initCyclic(allocator, Self.data_fn);
+            return Rc.initCyclic(allocator, Self.data_fn, .{});
         }
 
         pub fn me(self: *Self) Rc {
@@ -166,7 +166,7 @@ test "cyclic atomic" {
     };
 
     var gadget = try Gadget.init(alloc);
-    defer gadget.releaseWithFn(Gadget.deinit);
+    defer gadget.releaseWithFn(Gadget.deinit, .{});
 
     try expect(gadget.strongCount() == 1);
     try expect(gadget.weakCount() == 1);


### PR DESCRIPTION
Adds functions arguments for `initCyclic` and `releaseWithFn` that may contain more parameters other than the one provided by the implementation.