### PR TITLE
Update README.md with a more detailed import instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,33 @@ Reference-counted pointers for Zig inspired by Rust's [`Rc`](https://doc.rust-la
 ## How to use
 
 To use `zigrc`, import the `src/root.zig` file into your project, or add it as a module by running command shown below in your project directory.
+
 ```console
+# you can fetch via archive
 zig fetch "https://github.com/Aandreba/zigrc/archive/refs/tags/0.4.0.tar.gz" --save=zigrc
+
+# or fetch via git
+zig fetch "git+https://github.com/Aandreba/zigrc#<ref id>" --save=zigrc
 ```
+
 Then import it in your build file (`build.zig`):
 ```zig
 pub fn build(b: *std.Build) void {
 // ...
+    // Import the dependency
     const zigrc_dep = b.dependency("zigrc", .{});
+
+    // Extract the module
     const zigrc_mod = &zigrc_dep.artifact("zig-rc").root_module;
+
+    // Add the dependency as an import to your library/executable
     exe.root_module.addImport("zigrc", zigrc_mod);
     lib.root_module.addImport("zigrc", zigrc_mod);
-    exe_unit_tests.root_module.addImport("zigrc", zigrc_mod);
-    lib_unit_tests.root_module.addImport("zigrc", zigrc_mod);
+    unit_tests.root_module.addImport("zigrc", zigrc_mod);
 // ...
 }
 ```
+
 ## Example
 
 ```zig

--- a/README.md
+++ b/README.md
@@ -7,8 +7,23 @@ Reference-counted pointers for Zig inspired by Rust's [`Rc`](https://doc.rust-la
 
 ## How to use
 
-To use `zigrc`, import the `src/main.zig` file into your project, or [add it as a module](https://zig.guide/build-system/modules) on your build file.
-
+To use `zigrc`, import the `src/root.zig` file into your project, or add it as a module by running command shown below in your project directory.
+```console
+zig fetch "https://github.com/Aandreba/zigrc/archive/refs/tags/0.4.0.tar.gz" --save=zigrc
+```
+Then import it in your build file (`build.zig`):
+```zig
+pub fn build(b: *std.Build) void {
+// ...
+    const zigrc_dep = b.dependency("zigrc", .{});
+    const zigrc_mod = &zigrc_dep.artifact("zig-rc").root_module;
+    exe.root_module.addImport("zigrc", zigrc_mod);
+    lib.root_module.addImport("zigrc", zigrc_mod);
+    exe_unit_tests.root_module.addImport("zigrc", zigrc_mod);
+    lib_unit_tests.root_module.addImport("zigrc", zigrc_mod);
+// ...
+}
+```
 ## Example
 
 ```zig


### PR DESCRIPTION
A few months ago I submitted [an issue about insufficient import instructions provided in `README.md`](https://github.com/Aandreba/zigrc/issues/5). Before I could give any feedback, the issue is closed. However, after some trial and error, I successfully imported this project with the official Zig package manager. I updated the `README.md` file with this method and hope it helps.