### PR TITLE
Deprecate `releaseWithFn` in favor of `releaseUnwrap`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,5 @@
 coverage: clean
+    rm -rf kcov-out
     zig build test -Doptimize=Debug
     kcov --include-pattern=src/root.zig,src/tests.zig kcov-out zig-cache/o/**/test
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,42 +9,6 @@
     // with this value.
     .minimum_zig_version = "0.12.0",
 
-    // This field is optional.
-    // Each dependency must either provide a `url` and `hash`, or a `path`.
-    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
-    // Once all dependencies are fetched, `zig build` no longer requires
-    // internet connectivity.
-    .dependencies = .{
-        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
-        //.example = .{
-        //    // When updating this field to a new URL, be sure to delete the corresponding
-        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
-        //    // the new URL.
-        //    .url = "https://example.com/foo.tar.gz",
-        //
-        //    // This is computed from the file contents of the directory of files that is
-        //    // obtained after fetching `url` and applying the inclusion rules given by
-        //    // `paths`.
-        //    //
-        //    // This field is the source of truth; packages do not come from a `url`; they
-        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
-        //    // obtain a package matching this `hash`.
-        //    //
-        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
-        //    .hash = "...",
-        //
-        //    // When this is provided, the package is found in a directory relative to the
-        //    // build root. In this case the package's hash is irrelevant and therefore not
-        //    // computed. This field and `url` are mutually exclusive.
-        //    .path = "foo",
-
-        //    // When this is set to `true`, a package is declared to be lazily
-        //    // fetched. This makes the dependency only get fetched if it is
-        //    // actually used.
-        //    .lazy = false,
-        //},
-    },
-
     // Specifies the set of files and directories that are included in this package.
     // Only files and directories listed here are included in the `hash` that
     // is computed for this package.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,20 +1,7 @@
 .{
     .name = "zigrc",
-    // This is a [Semantic Version](https://semver.org/).
-    // In a future version of Zig it will be used for package deduplication.
     .version = "0.5.0",
-
-    // This field is optional.
-    // This is currently advisory only; Zig does not yet do anything
-    // with this value.
     .minimum_zig_version = "0.12.0",
-
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package.
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -82,7 +82,7 @@ test "cyclic" {
     };
 
     var gadget = try Gadget.init(alloc);
-    defer gadget.releaseWithFn(Gadget.deinit, .{});
+    defer if (gadget.releaseUnwrap()) |val| val.deinit();
 
     try expect(gadget.strongCount() == 1);
     try expect(gadget.weakCount() == 1);
@@ -166,7 +166,7 @@ test "cyclic atomic" {
     };
 
     var gadget = try Gadget.init(alloc);
-    defer gadget.releaseWithFn(Gadget.deinit, .{});
+    defer if (gadget.releaseUnwrap()) |val| val.deinit();
 
     try expect(gadget.strongCount() == 1);
     try expect(gadget.weakCount() == 1);


### PR DESCRIPTION
- **fixed alignment bug**
- **Update README.md with a more detailed import instruction**
- **modified the example to be more verbose**
- **deprecate releaseWithFn in favour of releaseUnwrap**
