### PR TITLE
Add support for Zig 0.14

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.14.0
       - name: Generate docs
         run: zig build
       - name: Upload artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.14.0
       - run: zig test src/tests.zig

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 zig-cache/
 zig-out/
+.zig-cache/
 kcov-out

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 coverage: clean
     rm -rf kcov-out
     zig build test -Doptimize=Debug
-    kcov --include-pattern=src/root.zig,src/tests.zig kcov-out zig-cache/o/**/test
+    kcov --include-pattern=src/root.zig,src/tests.zig kcov-out .zig-cache/o/**/test
 
 docs:
     zig build

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "zigrc",
-    .version = "0.5.0",
+    .name = .zigrc,
+    .fingerprint = 0xb74441c95b654394,
+    .version = "0.6.0",
     .minimum_zig_version = "0.12.0",
     .paths = .{
         "build.zig",


### PR DESCRIPTION
Due to changes to the expected format of the build.zig.zon file, this brakes support for 0.13 package managing.