### PR TITLE
Added cache optimizations to the internal layout of the reference counters

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -12,5 +12,5 @@ test:
     zig test src/tests.zig
 
 clean:
-    rm -rf zig-cache
+    rm -rf .zig-cache
     rm -rf zig-out

--- a/src/example.zig
+++ b/src/example.zig
@@ -6,6 +6,7 @@ const Mutex = Thread.Mutex;
 
 const ArrayList = std.ArrayList;
 const Arc = rc.Arc(Data);
+const Rc = rc.Rc(@Vector(8, f32));
 
 const THREADS = 8;
 
@@ -43,6 +44,15 @@ test "example" {
     defer owned_value.deinit();
 
     std.debug.print("{d}\n", .{owned_value.data.items});
+}
+
+test "st_example" {
+    std.debug.print("\n", .{});
+    std.debug.print("Data size: {}\n", .{@sizeOf(@Vector(8, f32))});
+    std.debug.print("Heap size: {}\n\n", .{Rc.total_size});
+
+    std.debug.print("Data align: {}\n", .{@alignOf(@Vector(8, f32))});
+    std.debug.print("Heap align: {}\n\n", .{Rc.internal_alignment});
 }
 
 fn thread_exec(data: Arc) !void {

--- a/src/example.zig
+++ b/src/example.zig
@@ -21,10 +21,10 @@ const Data = struct {
 test "example" {
     std.debug.print("\n", .{});
     std.debug.print("Data size: {}\n", .{@sizeOf(Data)});
-    std.debug.print("Heap size: {}\n\n", .{Arc.innerSize()});
+    std.debug.print("Heap size: {}\n\n", .{Arc.total_size});
 
     std.debug.print("Data align: {}\n", .{@alignOf(Data)});
-    std.debug.print("Heap align: {}\n\n", .{Arc.innerAlign()});
+    std.debug.print("Heap align: {}\n\n", .{Arc.internal_alignment});
 
     var value = try Arc.init(std.testing.allocator, .{});
     errdefer if (value.releaseUnwrap()) |inner| inner.deinit();

--- a/src/root.zig
+++ b/src/root.zig
@@ -444,10 +444,11 @@ pub fn RcAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) type {
         value: if (alignment) |a| *align(a) T else *T,
 
         const Self = @This();
-        const Inner = struct {
-            strong: usize,
-            weak: usize,
+        const Inner = extern struct {
             value: T align(alignment orelse @alignOf(T)),
+            // Align to the cache-line boundry to avoid writes to the value or counts invalidating the cache of the other
+            strong: usize align(std.atomic.cache_line),
+            weak: usize,
 
             fn innerSize() comptime_int {
                 return @sizeOf(@This());
@@ -698,10 +699,10 @@ pub fn ArcAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) type {
         value: if (alignment) |a| *align(a) T else *T,
 
         const Self = @This();
-        const Inner = struct {
-            strong: usize align(std.atomic.cache_line),
-            weak: usize align(std.atomic.cache_line),
+        const Inner = extern struct {
             value: T align(alignment orelse @alignOf(T)),
+            strong: usize align(std.atomic.cache_line),
+            weak: usize,
 
             fn innerSize() comptime_int {
                 return @sizeOf(@This());

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const rc = @import("root.zig");
 const expect = std.testing.expect;
-
 const alloc = std.testing.allocator;
 
 // SINGLE THREAD

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -57,10 +57,10 @@ test "weak" {
 
 test "cyclic" {
     const Gadget = struct {
-        _me: Weak,
+        _me: rc.Rc(@This()).Weak,
 
         const Self = @This();
-        const Rc = rc.Rc(Self);
+        const Rc = rc.Rc(@This());
         const Weak = Rc.Weak;
 
         pub fn init(allocator: std.mem.Allocator) !Rc {
@@ -141,7 +141,7 @@ test "weak atomic" {
 
 test "cyclic atomic" {
     const Gadget = struct {
-        _me: Weak,
+        _me: rc.Arc(@This()).Weak,
 
         const Self = @This();
         const Rc = rc.Arc(Self);


### PR DESCRIPTION
The heap-allocated memory of the RC's is now properly aligned and the atomic counters aligned to the cache boundry, so they do not cause [false sharing](https://en.wikipedia.org/wiki/False_sharing) problems to their own value nor nearby arbitrary allocations.